### PR TITLE
Update Copyright Footer to National Parks Board

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -1,4 +1,4 @@
-title: Skyrise Greenery
+title: National Parks Board
 url: https://skyrisegreenery.nparks.gov.sg
 favicon: /images/Icons/favicon.png
 colors:
@@ -15,7 +15,7 @@ colors:
       color: "#78a22f"
     - title: media-color-five
       color: "#f7d117"
-description: Gardens in the Sky
+description: Skyrise Greenery - Gardens in the Sky
 permalink: none
 baseurl: ""
 exclude:

--- a/index.md
+++ b/index.md
@@ -1,7 +1,7 @@
 ---
 layout: homepage
-title: Skyrise Greenery
-description: Gardens in the Sky
+title: National Parks Board
+description: Skyrise Greenery - Gardens in the Sky
 image: /images/Skyrise Greenery Logo.png
 permalink: /
 notification: NParks will never send an SMS to request for payment/money


### PR DESCRIPTION
Changed the title of the website from Skyrise greenery to National Parks Board. 
Request from NParks Comms